### PR TITLE
Replace Tentang Kami with Blog in header and add Blog to footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Logo from "./logo";
 
 const boring = [
+  { label: "Blog", href: "/blog" },
   { label: "Tentang Kami", href: "/tentang-kami" },
   { label: "Hubungi Kami", href: "/hubungi-kami" },
   { label: "Terma & Syarat", href: "/terma-dan-syarat" },

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -30,9 +30,9 @@ export const Navbar = () => {
                 <span className="text-sm font-medium">Lihat Peta</span>
               </Button>
             </Link>
-            <Link href="/tentang-kami">
+            <Link href="/blog">
               <Button variant="ghost" size="sm">
-                <span className="text-sm font-medium">Tentang Kami</span>
+                <span className="text-sm font-medium">Blog</span>
               </Button>
             </Link>
             <Link href="/hubungi-kami">


### PR DESCRIPTION
## Summary
- Replaced "Tentang Kami" navigation link with "Blog" in the header
- Added "Blog" link to the footer navigation

This change updates the main navigation to point to the blog section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates site navigation to surface the blog.
> 
> - Navbar: swap the "Tentang Kami" button for a "Blog" button linking to `/blog`
> - Footer: add `Blog` to the `boring` links list
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06855c5d868f60820a160bd5d5f7f2a4bc71f876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->