### PR TITLE
merge to amplify

### DIFF
--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -17,7 +17,7 @@ const s3Client = new S3Client({
   forcePathStyle: true, // Use path-style URLs to avoid SSL certificate issues
 });
 
-const BUCKET_NAME = process.env.AWS_S3_BUCKET_NAME!;
+const BUCKET_NAME = process.env.S3_BUCKET_NAME || process.env.AWS_S3_BUCKET_NAME!;
 
 export interface UploadResult {
   url: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds flexibility in S3 configuration.
> 
> - `BUCKET_NAME` now resolves `S3_BUCKET_NAME` first, falling back to `AWS_S3_BUCKET_NAME` in `src/lib/s3.ts` (no other logic changed)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c54660518c61c4bd935b8d72f4244143f0354c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->