### PR TITLE
Fix: Hardcode S3 bucket name as fallback

### DIFF
--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -17,7 +17,7 @@ const s3Client = new S3Client({
   forcePathStyle: true, // Use path-style URLs to avoid SSL certificate issues
 });
 
-const BUCKET_NAME = process.env.S3_BUCKET_NAME || process.env.AWS_S3_BUCKET_NAME!;
+const BUCKET_NAME = process.env.S3_BUCKET_NAME || process.env.AWS_S3_BUCKET_NAME || "dialisis.my";
 
 export interface UploadResult {
   url: string;


### PR DESCRIPTION
Amplify environment variables aren't reaching runtime. Hardcode bucket name as fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures S3 operations have a default bucket when environment variables are absent.
> 
> - Updates `BUCKET_NAME` in `src/lib/s3.ts` to fall back to `"dialisis.my"` if neither `S3_BUCKET_NAME` nor `AWS_S3_BUCKET_NAME` is provided
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a38bee03b1a18f2e33c0723b1c4dba9114674ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->