### PR TITLE
Remove .next/cache from Amplify cache paths

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -21,4 +21,3 @@ frontend:
     paths:
       - .npm/**/*
       - node_modules/**/*
-      - .next/cache/**/*


### PR DESCRIPTION
Prevents webpack cache accumulation across builds that was causing build output to exceed the 220MB limit.